### PR TITLE
feat(470): Validates a template yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,76 @@
 
 > A module for validating a Screwdriver Template file
 
+## yaml
+
+```yaml
+# example.yaml
+name: tkyi/nodejs_main
+version: 2.0.1
+description: |
+  Template for a NodeJS main job. Installs the NPM module dependencies and executes
+  the test target.
+maintainer: tiffanykyi@gmail.com
+config:
+  image: node:4
+  steps:
+    - install: npm install
+    - test: npm test
+  environment:
+    NODE_ENV: production
+  secrets:
+     - NPM_TOKEN
+
+```
+
 ## Usage
 
+
 ```bash
-npm install screwdriver-template-validator
+$ npm install screwdriver-template-validator
 ```
+
+Validate in Node.js:
+
+```javascript
+const fs = require('fs');  // standard fs module
+const validator = require('screwdriver-template-validator');
+
+// The "example.yaml" is the YAML described above
+validator(fs.readFileSync('example.yaml'))
+    .then((templateData) => {
+        console.log(templateData);
+    });
+```
+
+Output of the console.log():
+
+```javascript
+{
+    "name": "tkyi/nodejs_main",
+    "version": "2.0.1",
+    "description": "Template for a NodeJS main ...",  //truncated for brevity
+    "maintainer": "tiffanykyi@gmail.com",
+    "config": {
+        "environment": {
+            "NODE_ENV": "production"
+        },
+        "image": "node:4",
+        "secrets": [
+            "NPM_TOKEN"
+        ],
+        "steps": [{
+            "install": "npm install"
+        }, {
+            "test": "npm test"
+        }]
+    }
+}
+```
+
+
+
+
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const Joi = require('joi');
+const SCHEMA_CONFIG = require('screwdriver-data-schema').config.template.template;
+const Yaml = require('js-yaml');
+
+/**
+ * Loads the configuration from a stringified screwdriver-template.yaml
+ * @method loadTemplate
+ * @param  {String} yamlString Contents of screwdriver-template.yaml
+ * @return {Promise}           Promise that resolves to the template as a config object
+ */
+function loadTemplate(yamlString) {
+    return new Promise(resolve =>
+        resolve(Yaml.safeLoad(yamlString))
+    );
+}
+
+/**
+ * Validate the template configuration
+ * @method validateTemplate
+ * @param  {Object}         templateObj Configuration object that represents the template
+ * @return {Promise}                    Promise that resolves to the passed-in config object
+ */
+function validateTemplate(templateObj) {
+    return new Promise((resolve, reject) => {
+        Joi.validate(templateObj, SCHEMA_CONFIG, {
+            abortEarly: false
+        }, (err, data) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(data);
+        });
+    });
+}
+
+/**
+ * Parses the configuration from a screwdriver-template.yaml
+ * @method parseTemplate
+ * @param  {String} yamlString Contents of screwdriver-template.yaml
+ * @return {Promise}           Promise that resolves to the template as a config object
+ */
+function parseTemplate(yamlString) {
+    return loadTemplate(yamlString)
+    .then(validateTemplate);
+}
+
+module.exports = parseTemplate;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
     "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^3.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "joi": "^10.2.2",
+    "js-yaml": "^3.8.1",
+    "screwdriver-data-schema": "^16.2.0"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/test/data/bad_structure_template.yaml
+++ b/test/data/bad_structure_template.yaml
@@ -1,0 +1,10 @@
+name: template_namespace/template_name
+version: 1.2.3
+# description is intentionally omitted
+# description: template description
+maintainer: name@domain.suffix
+config:
+  image: image_name:image_tag
+  steps:
+    - first_step: first_command
+    - second_step: ./second_script.sh

--- a/test/data/valid_full_template.yaml
+++ b/test/data/valid_full_template.yaml
@@ -1,0 +1,13 @@
+name: template_namespace/template_name
+version: 1.2.3
+description: template description
+maintainer: name@domain.suffix
+config:
+  image: image_name:image_tag
+  steps:
+    - first_step: first_command
+    - second_step: ./second_script.sh
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,70 @@
 'use strict';
 
 const assert = require('chai').assert;
+const fs = require('fs');
+const path = require('path');
+
+const TEST_YAML_FOLDER = path.resolve(__dirname, 'data');
+const VALID_FULL_TEMPLATE_PATH = path.resolve(TEST_YAML_FOLDER, 'valid_full_template.yaml');
+const BAD_STRUCTURE_TEMPLATE_PATH = path.resolve(TEST_YAML_FOLDER, 'bad_structure_template.yaml');
 
 describe('index test', () => {
-    it('passes', () => {
-        assert.isTrue(true);
+    let validator;
+
+    beforeEach(() => {
+        /* eslint-disable global-require */
+        validator = require('../index');
+        /* eslint-enable global-require */
+    });
+
+    it('parses a valid yaml', () => {
+        const yamlString = fs.readFileSync(VALID_FULL_TEMPLATE_PATH);
+
+        return validator(yamlString)
+        .then((config) => {
+            assert.isObject(config);
+
+            assert.deepEqual(config, {
+                config: {
+                    environment: {
+                        KEYNAME: 'value'
+                    },
+                    image: 'image_name:image_tag',
+                    secrets: [
+                        'SECRET_NAME'
+                    ],
+                    steps: [
+                        {
+                            first_step: 'first_command'
+                        },
+                        {
+                            second_step: './second_script.sh'
+                        }
+                    ]
+                },
+                description: 'template description',
+                maintainer: 'name@domain.suffix',
+                name: 'template_namespace/template_name',
+                version: '1.2.3'
+            });
+        });
+    });
+
+    it('throws when parsing incorrectly formatted yaml', () => {
+        const yamlString = 'main: :';
+
+        return validator(yamlString)
+        .then(assert.fail, (err) => {
+            assert.match(err, /YAMLException/);
+        });
+    });
+
+    it('throws when parsing a poorly structured template', () => {
+        const yamlString = fs.readFileSync(BAD_STRUCTURE_TEMPLATE_PATH);
+
+        return validator(yamlString)
+        .then(assert.fail, (err) => {
+            assert.match(err, /ValidationError/);
+        });
     });
 });


### PR DESCRIPTION
## Context

The [`screwdriver-config-parser`](https://github.com/screwdriver-cd/config-parser) is utilized to validate a `screwdriver.yaml` that it meets structural and functional specifications. We want to provide and use a similar module, but for `screwdriver-template.yaml`. 

Since the `screwdriver-config-parser` does very well by focusing on the `screwdriver.yaml`, we wanted to have a separate module that's single responsibility is on the template file. 

## Objective

This PR aims to allow the caller to provide a `screwdriver-template.yaml` (in the form of a string) and receive the JSON representation of it. This function only parses the given template and validates it. 

## Notes

* Contributes to screwdriver-cd/screwdriver#470

EDIT: Included changes introduced with screwdriver-cd/data-schema#109