### PR TITLE
refactor: thorough test of poorly structured template

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
+    "hoek": "^4.1.0",
     "jenkins-mocha": "^3.0.0"
   },
   "dependencies": {

--- a/test/data/bad_structure_template.yaml
+++ b/test/data/bad_structure_template.yaml
@@ -1,10 +1,12 @@
 name: template_namespace/template_name
 version: 1.2.3
-# description is intentionally omitted
+# description is intentionally omitted to test an error case
 # description: template description
 maintainer: name@domain.suffix
 config:
-  image: image_name:image_tag
+  # Image is supposed to be a string
+  # Is intentionally a Number to test an error case
+  image: 1
   steps:
     - first_step: first_command
     - second_step: ./second_script.sh


### PR DESCRIPTION
## Context

The validator does well with invalidating a poorly structured configuration. However, it was unclear how the caller could respond to an error returned from the validator. Was the field supposed to be a string? Was the field required?

Research required the caller to look beyond the module and how the `joi` module works. Although the intention is to leverage `joi`-based errors, this "how do I handle errors" is a leaky abstraction that causes the user to climb through the dependency chain to figure it out.

## Objective

Expanded the test to better describe how to parse a validation error.