### PR TITLE
feat(470): improved response structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,25 @@ function validateTemplate(templateObj) {
  * Parses the configuration from a screwdriver-template.yaml
  * @method parseTemplate
  * @param  {String} yamlString Contents of screwdriver-template.yaml
- * @return {Promise}           Promise that resolves to the template as a config object
+ * @return {Promise}           Promise that rejects if the configuration cannot be parsed
+ *                             The promise will eventually resolve into:
+ *         {Object}   result
+ *         {Object}   result.template  The parsed template that was validated
+ *         {Object[]} result.errors    An array of objects related to validating
+ *                                     the given template
  */
 function parseTemplate(yamlString) {
     return loadTemplate(yamlString)
-    .then(validateTemplate);
+    .then(configToValidate =>
+        validateTemplate(configToValidate)
+        .then(templateConfiguration => ({
+            errors: [],
+            template: templateConfiguration
+        }), err => ({
+            errors: err.details,
+            template: configToValidate
+        }))
+    );
 }
 
 module.exports = parseTemplate;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
+    "hoek": "^4.1.0",
     "jenkins-mocha": "^3.0.0"
   },
   "dependencies": {

--- a/test/data/bad_structure_template.yaml
+++ b/test/data/bad_structure_template.yaml
@@ -1,10 +1,16 @@
 name: template_namespace/template_name
 version: 1.2.3
-# description is intentionally omitted
+# description is intentionally omitted to assert an error case
 # description: template description
 maintainer: name@domain.suffix
 config:
-  image: image_name:image_tag
+  # image is supposed to be a string
+  # is intentionally a Number type to assert an error case
+  image: 1
   steps:
     - first_step: first_command
     - second_step: ./second_script.sh
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME


### PR DESCRIPTION
## Context

The validator does well with invalidating a poorly structure configuration. However, it was unclear how the caller could respond to an error returned from the validator. Was the field supposed to be a string? Was the field required? Was the input even valid in the first place?

Investigating errors required the caller to look beyond the module and how the `joi` module works. Although the intention is to leverage `joi`-based errors, this "how do I handle errors" is a leaky abstraction that causes the user to climb through the dependency chain to figure it out.

## Objective

This change addresses it by distinguishing what is an error case and what is a valid parse attempt that has validation errors.

# Other Notes

* Related to screwdriver-cd/screwdriver#470
* Affects screwdriver-cd/screwdriver#480

EDIT: Referenced the wrong PR