### PR TITLE
fix: Update hoek and joi packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "hoek": "^4.1.0",
+    "hoek": "^5.0.3",
     "jenkins-mocha": "^3.0.0"
   },
   "dependencies": {
-    "joi": "^10.2.2",
+    "joi": "^13.0.0",
     "js-yaml": "^3.8.1",
     "screwdriver-data-schema": "^18.0.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,13 +84,14 @@ describe('index test', () => {
             assert.strictEqual(result.errors.length, 2);
 
             // check required description
-            const missingField = hoek.reach(result.template, result.errors[0].path);
+            const missingField = hoek.reach(result.template, result.errors[0].path[0]);
 
             assert.strictEqual(result.errors[0].message, '"description" is required');
             assert.isUndefined(missingField);
 
             // check incorrect type
-            const incorrectType = hoek.reach(result.template, result.errors[1].path);
+            const chain = `${result.errors[1].path[0]}.${result.errors[1].path[1]}`;
+            const incorrectType = hoek.reach(result.template, chain);
 
             assert.strictEqual(result.errors[1].message, '"image" must be a string');
             assert.isNumber(incorrectType);


### PR DESCRIPTION
Update for Snyk vulnerabilities for https://github.com/screwdriver-cd/screwdriver/pull/884

Hoek reach no longer supports arrays in their chains