### PR TITLE
fix: Use semantic release template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,16 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        requires: [main]
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
Related to https://github.com/screwdriver-cd/executor-docker/pull/19