### PR TITLE
feat(1959): Publish major version. BREAKING CHANGES: hapi v19 upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.template.template;
 const Yaml = require('js-yaml');
 
@@ -10,10 +9,8 @@ const Yaml = require('js-yaml');
  * @param  {String} yamlString Contents of screwdriver-template.yaml
  * @return {Promise}           Promise that resolves to the template as a config object
  */
-function loadTemplate(yamlString) {
-    return new Promise(resolve =>
-        resolve(Yaml.safeLoad(yamlString))
-    );
+async function loadTemplate(yamlString) {
+    return Yaml.safeLoad(yamlString);
 }
 
 /**
@@ -22,18 +19,16 @@ function loadTemplate(yamlString) {
  * @param  {Object}         templateObj Configuration object that represents the template
  * @return {Promise}                    Promise that resolves to the passed-in config object
  */
-function validateTemplate(templateObj) {
-    return new Promise((resolve, reject) => {
-        Joi.validate(templateObj, SCHEMA_CONFIG, {
+async function validateTemplate(templateObj) {
+    try {
+        const data = await SCHEMA_CONFIG.validateAsync(templateObj, {
             abortEarly: false
-        }, (err, data) => {
-            if (err) {
-                return reject(err);
-            }
-
-            return resolve(data);
         });
-    });
+
+        return data;
+    } catch (err) {
+        throw err;
+    }
 }
 
 /**
@@ -42,23 +37,32 @@ function validateTemplate(templateObj) {
  * @param  {String}  yamlString Contents of screwdriver-template.yaml
  * @return {Promise}            Promise that rejects if the configuration cannot be parsed
  *                              The promise will eventually resolve into:
- *         {Object}   result
- *         {Object}   result.template  The parsed template that was validated
- *         {Object[]} result.errors    An array of objects related to validating
- *                                     the given template
+ * {Object}   result
+ * {Object}   result.template  The parsed template that was validated
+ * {Object[]} result.errors    An array of objects related to validating
+ *                             the given template
  */
-function parseTemplate(yamlString) {
-    return loadTemplate(yamlString)
-        .then(configToValidate =>
-            validateTemplate(configToValidate)
-                .then(templateConfiguration => ({
-                    errors: [],
-                    template: templateConfiguration
-                }), err => ({
-                    errors: err.details,
-                    template: configToValidate
-                }))
-        );
+async function parseTemplate(yamlString) {
+    let configToValidate;
+
+    try {
+        configToValidate = await loadTemplate(yamlString);
+        const templateConfiguration = await validateTemplate(configToValidate);
+
+        return {
+            errors: [],
+            template: templateConfiguration
+        };
+    } catch (err) {
+        if (!err.details) {
+            throw err;
+        }
+
+        return {
+            errors: err.details,
+            template: configToValidate
+        };
+    }
 }
 
 module.exports = parseTemplate;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-template-validator",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "A module for validating a Screwdriver Template file",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
   "dependencies": {
     "joi": "^17.1.1",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
+    "screwdriver-data-schema": "^20.0.0"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -31,16 +31,16 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
+    "@hapi/hoek": "^9.0.4",
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "hoek": "^5.0.4",
-    "jenkins-mocha": "^6.0.0"
+    "mocha": "^8.1.0"
   },
   "dependencies": {
-    "joi": "^13.7.0",
+    "joi": "^17.1.1",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "^19.1.1"
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/data/bad_structure_template.yaml
+++ b/test/data/bad_structure_template.yaml
@@ -2,7 +2,7 @@ name: template_namespace/template_name
 version: 1.2.3
 # description is intentionally omitted to assert an error case
 # description: template description
-maintainer: name@domain.suffix
+maintainer: name@domain.com
 config:
   # image is supposed to be a string
   # is intentionally a Number type to assert an error case

--- a/test/data/valid_full_template.yaml
+++ b/test/data/valid_full_template.yaml
@@ -1,7 +1,7 @@
 name: template_namespace/template_name
 version: 1.2.3
 description: template description
-maintainer: name@domain.suffix
+maintainer: name@domain.org
 config:
   image: image_name:image_tag
   steps:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const fs = require('fs');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const path = require('path');
 
 const TEST_YAML_FOLDER = path.resolve(__dirname, 'data');
@@ -45,7 +45,7 @@ describe('index test', () => {
                             ]
                         },
                         description: 'template description',
-                        maintainer: 'name@domain.suffix',
+                        maintainer: 'name@domain.org',
                         name: 'template_namespace/template_name',
                         version: '1.2.3'
                     }
@@ -76,7 +76,7 @@ describe('index test', () => {
                             }
                         ]
                     },
-                    maintainer: 'name@domain.suffix',
+                    maintainer: 'name@domain.com',
                     name: 'template_namespace/template_name',
                     version: '1.2.3'
                 });
@@ -92,7 +92,7 @@ describe('index test', () => {
                 const chain = `${result.errors[1].path[0]}.${result.errors[1].path[1]}`;
                 const incorrectType = hoek.reach(result.template, chain);
 
-                assert.strictEqual(result.errors[1].message, '"image" must be a string');
+                assert.strictEqual(result.errors[1].message, '"config.image" must be a string');
                 assert.isNumber(incorrectType);
             }, assert.fail);
     });


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
