### PR TITLE
feat(2319): [2] Support template composition. BREAKING CHANGE: must pass in template factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+package-lock.json
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Template Validator
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] ![License][license-image]
 
-> A module for validating a Screwdriver Template file
+> A module for validating and parsing a Screwdriver Template file
 
 ## yaml
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function validateTemplate(templateObj) {
  */
 async function flattenTemplate(templateObj, templateFactory) {
     // If template is specified, then merge
-    if (templateObj.config.template) {
+    if (templateObj.config.template && templateFactory) {
         const { childJobConfig, parentTemplateImages } = await helper.mergeTemplateIntoJob(
             templateObj, templateFactory
         );

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -3,6 +3,21 @@
 const Hoek = require('@hapi/hoek');
 
 /**
+ * Convert job steps from array to object for faster lookup
+ * @method convertFromArrayToObject
+ * @param  {Array} steps Job step array of objects
+ * @return {Object}      Job object
+ */
+function convertFromArrayToObject(steps) {
+    return steps.reduce((obj, item) => {
+        const key = Object.keys(item)[0];
+
+        obj[key] = item[key];
+
+        return obj;
+    }, {});
+}
+/**
  * Merge oldJob into newJob
  * "oldJob" takes precedence over "newJob". For ex: child template job settings > parent template job settings
  * @param  {Object}   newJob        Job to be merged into. For ex: parent template
@@ -10,6 +25,8 @@ const Hoek = require('@hapi/hoek');
  * @param  {Boolean}  fromTemplate  Whether this is merged from template. If true, perform extra actions such as wrapping.
  */
 function merge(newJob, oldJob, fromTemplate) {
+    let warnings = [];
+
     // Intialize new job with default fields (environment, settings, and secrets)
     newJob.annotations = newJob.annotations || {};
     newJob.environment = newJob.environment || {};
@@ -52,7 +69,34 @@ function merge(newJob, oldJob, fromTemplate) {
     newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];
     newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
 
-    if (fromTemplate && oldJob.steps) {
+    // Use "order" to get steps, ignore all other steps; current template
+    // has precedence over external template
+    if (fromTemplate && oldJob.order) {
+        let stepName;
+        const mergedSteps = [];
+
+        // Convert steps from array to object for faster lookup
+        const oldSteps = convertFromArrayToObject(oldJob.steps);
+        const newSteps = convertFromArrayToObject(newJob.steps);
+
+        for (let i = 0; i < oldJob.order.length; i += 1) {
+            stepName = oldJob.order[i];
+
+            if (oldSteps && oldSteps[stepName]) {
+                mergedSteps.push({ [stepName]: oldSteps[stepName] });
+            } else if (newSteps && newSteps[stepName]) {
+                mergedSteps.push({ [stepName]: newSteps[stepName] });
+            } else {
+                warnings = warnings.concat(
+                    // eslint-disable-next-line max-len
+                    `${stepName} step in cannot be found in current template or ${oldJob.template} template; skipping`
+                );
+            }
+        }
+
+        newJob.steps = mergedSteps;
+    // Basic step merge with template
+    } else if (fromTemplate && oldJob.steps) {
         let stepName;
         let preStepName;
         let postStepName;
@@ -104,6 +148,8 @@ function merge(newJob, oldJob, fromTemplate) {
 
         newJob.steps = mergedSteps;
     }
+
+    return warnings;
 }
 
 /**
@@ -145,7 +191,8 @@ async function mergeTemplateIntoJob(templateObj, templateFactory) {
                 SD_TEMPLATE_VERSION: template.version
             });
 
-            merge(newJob, oldJob, true);
+            const warnings = merge(newJob, oldJob, true);
+
             delete newJob.template;
 
             newJob.templateId = template.id;
@@ -159,7 +206,8 @@ async function mergeTemplateIntoJob(templateObj, templateFactory) {
 
             return {
                 childJobConfig: newJob,
-                parentTemplateImages: template.images
+                parentTemplateImages: template.images,
+                warnings
             };
         });
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const Hoek = require('@hapi/hoek');
+
+/**
+ * Merge oldJob into newJob
+ * "oldJob" takes precedence over "newJob". For ex: child template job settings > parent template job settings
+ * @param  {Object}   newJob        Job to be merged into. For ex: parent template
+ * @param  {Object}   oldJob        Job to merge. For ex: child template
+ * @param  {Boolean}  fromTemplate  Whether this is merged from template. If true, perform extra actions such as wrapping.
+ */
+function merge(newJob, oldJob, fromTemplate) {
+    // Intialize new job with default fields (environment, settings, and secrets)
+    newJob.annotations = newJob.annotations || {};
+    newJob.environment = newJob.environment || {};
+    newJob.settings = newJob.settings || {};
+
+    // Merge
+    Object.assign(newJob.annotations, oldJob.annotations || {});
+    Object.assign(newJob.environment, oldJob.environment || {});
+    Object.assign(newJob.settings, oldJob.settings || {});
+    newJob.image = oldJob.image || newJob.image;
+
+    if (oldJob.requires) {
+        newJob.requires = [].concat(oldJob.requires);
+    } // otherwise, keep it the same, or don't set if it wasn't set
+
+    if (oldJob.blockedBy) {
+        newJob.blockedBy = [].concat(oldJob.blockedBy);
+    }
+
+    if (oldJob.freezeWindows) {
+        newJob.freezeWindows = [].concat(oldJob.freezeWindows);
+    }
+
+    if (oldJob.cache || oldJob.cache === false) {
+        newJob.cache = oldJob.cache;
+    }
+
+    // Merge secrets
+    const newSecrets = newJob.secrets || [];
+    const oldSecrets = oldJob.secrets || [];
+
+    // Merge sourcePaths
+    let newsourcePaths = newJob.sourcePaths || [];
+    let oldsourcePaths = oldJob.sourcePaths || [];
+
+    newsourcePaths = Array.isArray(newsourcePaths) ? newsourcePaths : [newsourcePaths];
+    oldsourcePaths = Array.isArray(oldsourcePaths) ? oldsourcePaths : [oldsourcePaths];
+
+    // remove duplicate
+    newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];
+    newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
+
+    if (fromTemplate && oldJob.steps) {
+        let stepName;
+        let preStepName;
+        let postStepName;
+        const mergedSteps = [];
+        const teardownSteps = [];
+
+        // convert steps from oldJob from array to object for faster lookup
+        const oldSteps = oldJob.steps.reduce((obj, item) => {
+            const key = Object.keys(item)[0];
+
+            if (key.startsWith('teardown-')) {
+                teardownSteps.push(key);
+            }
+
+            obj[key] = item[key];
+
+            return obj;
+        }, {});
+
+        for (let i = 0; i < newJob.steps.length; i += 1) {
+            [stepName] = Object.keys(newJob.steps[i]);
+            preStepName = `pre${stepName}`;
+            postStepName = `post${stepName}`;
+
+            // add pre-step
+            if (oldSteps[preStepName]) {
+                mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
+            }
+
+            // if user doesn't define the same step, add it
+            if (!oldSteps[stepName]) {
+                mergedSteps.push(newJob.steps[i]);
+            } else if (!stepName.startsWith('teardown-')) {
+                // if user defines the same step, only add if it's not teardown
+                // otherwise, skip (it will be overriden later, otherwise will get duplicate steps)
+                mergedSteps.push({ [stepName]: oldSteps[stepName] });
+            }
+
+            // add post-step
+            if (oldSteps[postStepName]) {
+                mergedSteps.push({ [postStepName]: oldSteps[postStepName] });
+            }
+        }
+
+        for (let i = 0; i < teardownSteps.length; i += 1) {
+            stepName = teardownSteps[i];
+            mergedSteps.push({ [stepName]: oldSteps[stepName] });
+        }
+
+        newJob.steps = mergedSteps;
+    }
+}
+
+/**
+ * Retrieve template and merge into job config
+ * @method mergeTemplateIntoJob
+ * @param  {Object}           templateObj       Template object with job config
+ * @param  {TemplateFactory}  templateFactory   Template Factory to get template from
+ * @return {Promise}                            Resolves with obj with:
+ *                                              - new flattened job config
+ *                                              - parent template images object
+ */
+async function mergeTemplateIntoJob(templateObj, templateFactory) {
+    // Child template config
+    const oldJob = templateObj.config;
+
+    // Try to get the template
+    return templateFactory.getTemplate(oldJob.template)
+        .then((template) => {
+            if (!template) {
+                throw new Error(`Template ${oldJob.template} does not exist`);
+            }
+
+            // Parent template config
+            const newJob = template.config;
+            const environment = newJob.environment || {};
+
+            // Construct full template name
+            let fullName = template.name;
+
+            if (template.namespace && template.namespace !== 'default') {
+                fullName = `${template.namespace}/${template.name}`;
+            }
+
+            // Inject template full name, name, namespace, and version to env
+            newJob.environment = Hoek.merge(environment, {
+                SD_TEMPLATE_FULLNAME: fullName,
+                SD_TEMPLATE_NAME: template.name,
+                SD_TEMPLATE_NAMESPACE: template.namespace || '',
+                SD_TEMPLATE_VERSION: template.version
+            });
+
+            merge(newJob, oldJob, true);
+            delete newJob.template;
+
+            newJob.templateId = template.id;
+
+            // If template.images contains a label match for the image defined in the job
+            // set the job image to the respective template image
+            if (typeof template.images !== 'undefined'
+                && typeof template.images[newJob.image] !== 'undefined') {
+                newJob.image = template.images[newJob.image];
+            }
+
+            return {
+                childJobConfig: newJob,
+                parentTemplateImages: template.images
+            };
+        });
+}
+
+module.exports = {
+    merge,
+    mergeTemplateIntoJob
+};

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -69,32 +69,40 @@ function merge(newJob, oldJob, fromTemplate) {
     newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];
     newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
 
-    // Use "order" to get steps, ignore all other steps; current template
-    // has precedence over external template
+    // Use "order" to get steps, ignore all other steps;
+    // current template has precedence over external template
     if (fromTemplate && oldJob.order) {
         let stepName;
         const mergedSteps = [];
+        const teardownSteps = [];
 
         // Convert steps from array to object for faster lookup
         const oldSteps = convertFromArrayToObject(oldJob.steps);
         const newSteps = convertFromArrayToObject(newJob.steps);
 
         for (let i = 0; i < oldJob.order.length; i += 1) {
+            let step;
+
             stepName = oldJob.order[i];
 
             if (oldSteps && oldSteps[stepName]) {
-                mergedSteps.push({ [stepName]: oldSteps[stepName] });
+                step = { [stepName]: oldSteps[stepName] };
             } else if (newSteps && newSteps[stepName]) {
-                mergedSteps.push({ [stepName]: newSteps[stepName] });
+                step = { [stepName]: newSteps[stepName] };
             } else {
-                warnings = warnings.concat(
-                    // eslint-disable-next-line max-len
-                    `${stepName} step in cannot be found in current template or ${oldJob.template} template; skipping`
-                );
+                warnings = warnings.concat(`${stepName} step definition not found; skipping`);
+            }
+
+            if (step) {
+                if (stepName.startsWith('teardown-')) {
+                    teardownSteps.push(step);
+                } else {
+                    mergedSteps.push(step);
+                }
             }
         }
 
-        newJob.steps = mergedSteps;
+        newJob.steps = mergedSteps.concat(teardownSteps);
     // Basic step merge with template
     } else if (fromTemplate && oldJob.steps) {
         let stepName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-template-validator",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A module for validating a Screwdriver Template file",
   "main": "index.js",
   "scripts": {
@@ -31,16 +31,17 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "@hapi/hoek": "^9.0.4",
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "mocha": "^8.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "sinon": "^9.2.4"
   },
   "dependencies": {
+    "@hapi/hoek": "^9.0.4",
     "joi": "^17.1.1",
     "js-yaml": "^3.12.1",
     "screwdriver-data-schema": "^21.0.0"

--- a/test/data/template.json
+++ b/test/data/template.json
@@ -1,0 +1,30 @@
+{
+    "id": 7754,
+    "namespace": "template_namespace",
+    "name": "parent",
+    "version": "1.2.3",
+    "description": "test template",
+    "maintainer": "bar@foo.com",
+    "labels": [],
+    "images": {
+        "stable-image": "node:8",
+        "latest-image": "node:12"
+    },
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "test": "npm test" }
+        ],
+        "environment": {
+            "FOO": "from template",
+            "BAR": "foo"
+        },
+        "secrets": [
+            "GIT_KEY"
+        ],
+        "settings": {
+            "email": "foo@example.com"
+        }
+    }
+}

--- a/test/data/template.json
+++ b/test/data/template.json
@@ -14,7 +14,8 @@
         "image": "node:4",
         "steps": [
             { "install": "npm install" },
-            { "test": "npm test" }
+            { "test": "npm test" },
+            { "teardown-run": "cp -r artifacts/coverage $SD_ARTIFACTS_DIR" }
         ],
         "environment": {
             "FOO": "from template",

--- a/test/data/valid_template_with_order_template.yaml
+++ b/test/data/valid_template_with_order_template.yaml
@@ -1,0 +1,23 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+    stable-image: node:10
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  order:
+    - init
+    - install
+    - test
+    - finish
+  steps:
+    - init: echo Starting command
+    - install: ./run_script.sh
+    - finish: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/valid_template_with_order_warnings_template.yaml
+++ b/test/data/valid_template_with_order_warnings_template.yaml
@@ -1,0 +1,25 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+    stable-image: node:10
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  order:
+    - init
+    - install
+    - test
+    - blah
+    - finish
+    - meow
+  steps:
+    - init: echo Starting command
+    - install: ./run_script.sh
+    - finish: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/valid_template_with_order_wrong_teardown_template.yaml
+++ b/test/data/valid_template_with_order_wrong_teardown_template.yaml
@@ -1,0 +1,26 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+    stable-image: node:10
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  order:
+    - init
+    - teardown-blah
+    - install
+    - teardown-run
+    - test
+    - finish
+  steps:
+    - init: echo Starting command
+    - teardown-blah: echo Should be before teardown-run
+    - install: ./run_script.sh
+    - finish: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/valid_template_with_parent_template.yaml
+++ b/test/data/valid_template_with_parent_template.yaml
@@ -1,0 +1,19 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+    stable-image: node:10
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  steps:
+    - preinstall: echo Starting command
+    - install: first_command
+    - posttest: ./second_script.sh
+    - teardown-always: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,8 @@ const sinon = require('sinon');
 const VALID_FULL_TEMPLATE_PATH = 'valid_full_template.yaml';
 const VALID_PARENT_TEMPLATE_PATH = 'valid_template_with_parent_template.yaml';
 const VALID_TEMPLATE_PATH_WITH_ORDER = 'valid_template_with_order_template.yaml';
+const VALID_TEMPLATE_PATH_WITH_ORDER_AND_WRONG_TEARDOWN =
+    'valid_template_with_order_wrong_teardown_template.yaml';
 const VALID_TEMPLATE_PATH_WITH_ORDER_WARNINGS = 'valid_template_with_order_warnings_template.yaml';
 const BAD_STRUCTURE_TEMPLATE_PATH = 'bad_structure_template.yaml';
 
@@ -113,6 +115,9 @@ describe('index test', () => {
                                     posttest: './second_script.sh'
                                 },
                                 {
+                                    'teardown-run': 'cp -r artifacts/coverage $SD_ARTIFACTS_DIR'
+                                },
+                                {
                                     'teardown-always': 'echo done!'
                                 }
                             ],
@@ -189,6 +194,69 @@ describe('index test', () => {
             })
     );
 
+    it('parses a valid yaml using a parent template with order and wrong teardown', () =>
+        validator(loadData(VALID_TEMPLATE_PATH_WITH_ORDER_AND_WRONG_TEARDOWN), templateFactoryMock)
+            .then((config) => {
+                assert.isObject(config);
+                assert.deepEqual(config, {
+                    errors: [],
+                    template: {
+                        config: {
+                            annotations: {},
+                            environment: {
+                                BAR: 'foo',
+                                FOO: 'from template',
+                                KEYNAME: 'value',
+                                SD_TEMPLATE_FULLNAME: 'template_namespace/parent',
+                                SD_TEMPLATE_NAME: 'parent',
+                                SD_TEMPLATE_NAMESPACE: 'template_namespace',
+                                SD_TEMPLATE_VERSION: '1.2.3'
+                            },
+                            image: 'node:8',
+                            secrets: [
+                                'GIT_KEY',
+                                'SECRET_NAME'
+                            ],
+                            settings: {
+                                email: 'foo@example.com'
+                            },
+                            sourcePaths: [],
+                            steps: [
+                                {
+                                    init: 'echo Starting command'
+                                },
+                                {
+                                    install: './run_script.sh'
+                                },
+                                {
+                                    test: 'npm test'
+                                },
+                                {
+                                    finish: 'echo done!'
+                                },
+                                {
+                                    'teardown-blah': 'echo Should be before teardown-run'
+                                },
+                                {
+                                    'teardown-run': 'cp -r artifacts/coverage $SD_ARTIFACTS_DIR'
+                                }
+                            ],
+                            templateId: 7754
+                        },
+                        description: 'template description',
+                        images: {
+                            'latest-image': 'node:12',
+                            'stable-image': 'node:10',
+                            'test-image': 'node:18'
+                        },
+                        maintainer: 'name@domain.org',
+                        name: 'template_namespace/child',
+                        version: '1.2.3'
+                    }
+                });
+            })
+    );
+
     it('parses a valid yaml using a parent template with order and warnings', () =>
         validator(loadData(VALID_TEMPLATE_PATH_WITH_ORDER_WARNINGS), templateFactoryMock)
             .then((config) => {
@@ -242,12 +310,10 @@ describe('index test', () => {
                         name: 'template_namespace/child',
                         version: '1.2.3'
                     },
-                    /* eslint-disable max-len */
                     warnMessages: [
-                        'blah step in cannot be found in current template or template_namespace/parent@1 template; skipping',
-                        'meow step in cannot be found in current template or template_namespace/parent@1 template; skipping'
+                        'blah step definition not found; skipping',
+                        'meow step definition not found; skipping'
                     ]
-                    /* eslint-enable max-len */
                 });
             })
     );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,8 @@ const sinon = require('sinon');
 
 const VALID_FULL_TEMPLATE_PATH = 'valid_full_template.yaml';
 const VALID_PARENT_TEMPLATE_PATH = 'valid_template_with_parent_template.yaml';
+const VALID_TEMPLATE_PATH_WITH_ORDER = 'valid_template_with_order_template.yaml';
+const VALID_TEMPLATE_PATH_WITH_ORDER_WARNINGS = 'valid_template_with_order_warnings_template.yaml';
 const BAD_STRUCTURE_TEMPLATE_PATH = 'bad_structure_template.yaml';
 
 /**
@@ -126,6 +128,126 @@ describe('index test', () => {
                         name: 'template_namespace/child',
                         version: '1.2.3'
                     }
+                });
+            })
+    );
+
+    it('parses a valid yaml using a parent template with order', () =>
+        validator(loadData(VALID_TEMPLATE_PATH_WITH_ORDER), templateFactoryMock)
+            .then((config) => {
+                assert.isObject(config);
+                assert.deepEqual(config, {
+                    errors: [],
+                    template: {
+                        config: {
+                            annotations: {},
+                            environment: {
+                                BAR: 'foo',
+                                FOO: 'from template',
+                                KEYNAME: 'value',
+                                SD_TEMPLATE_FULLNAME: 'template_namespace/parent',
+                                SD_TEMPLATE_NAME: 'parent',
+                                SD_TEMPLATE_NAMESPACE: 'template_namespace',
+                                SD_TEMPLATE_VERSION: '1.2.3'
+                            },
+                            image: 'node:8',
+                            secrets: [
+                                'GIT_KEY',
+                                'SECRET_NAME'
+                            ],
+                            settings: {
+                                email: 'foo@example.com'
+                            },
+                            sourcePaths: [],
+                            steps: [
+                                {
+                                    init: 'echo Starting command'
+                                },
+                                {
+                                    install: './run_script.sh'
+                                },
+                                {
+                                    test: 'npm test'
+                                },
+                                {
+                                    finish: 'echo done!'
+                                }
+                            ],
+                            templateId: 7754
+                        },
+                        description: 'template description',
+                        images: {
+                            'latest-image': 'node:12',
+                            'stable-image': 'node:10',
+                            'test-image': 'node:18'
+                        },
+                        maintainer: 'name@domain.org',
+                        name: 'template_namespace/child',
+                        version: '1.2.3'
+                    }
+                });
+            })
+    );
+
+    it('parses a valid yaml using a parent template with order and warnings', () =>
+        validator(loadData(VALID_TEMPLATE_PATH_WITH_ORDER_WARNINGS), templateFactoryMock)
+            .then((config) => {
+                assert.isObject(config);
+                assert.deepEqual(config, {
+                    errors: [],
+                    template: {
+                        config: {
+                            annotations: {},
+                            environment: {
+                                BAR: 'foo',
+                                FOO: 'from template',
+                                KEYNAME: 'value',
+                                SD_TEMPLATE_FULLNAME: 'template_namespace/parent',
+                                SD_TEMPLATE_NAME: 'parent',
+                                SD_TEMPLATE_NAMESPACE: 'template_namespace',
+                                SD_TEMPLATE_VERSION: '1.2.3'
+                            },
+                            image: 'node:8',
+                            secrets: [
+                                'GIT_KEY',
+                                'SECRET_NAME'
+                            ],
+                            settings: {
+                                email: 'foo@example.com'
+                            },
+                            sourcePaths: [],
+                            steps: [
+                                {
+                                    init: 'echo Starting command'
+                                },
+                                {
+                                    install: './run_script.sh'
+                                },
+                                {
+                                    test: 'npm test'
+                                },
+                                {
+                                    finish: 'echo done!'
+                                }
+                            ],
+                            templateId: 7754
+                        },
+                        description: 'template description',
+                        images: {
+                            'latest-image': 'node:12',
+                            'stable-image': 'node:10',
+                            'test-image': 'node:18'
+                        },
+                        maintainer: 'name@domain.org',
+                        name: 'template_namespace/child',
+                        version: '1.2.3'
+                    },
+                    /* eslint-disable max-len */
+                    warnMessages: [
+                        'blah step in cannot be found in current template or template_namespace/parent@1 template; skipping',
+                        'meow step in cannot be found in current template or template_namespace/parent@1 template; skipping'
+                    ]
+                    /* eslint-enable max-len */
                 });
             })
     );


### PR DESCRIPTION
## Context

It would be nice if template owners could use templates in their template configs.

## Objective

This PR fetches template if it exists in the job config section and merges it accordingly.
Also merged `images` field.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319
Blocked by https://github.com/screwdriver-cd/data-schema/pull/431

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
