### PR TITLE
fix(2319): Fix image alias for template composition

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,12 +50,18 @@ async function flattenTemplate(templateObj, templateFactory) {
         warnMessages = warnings;
         templateObj.config = childJobConfig;
 
-        // Merge images object; maintainer, version, description, and
-        // template name will not be merged
+        // Merge images object
         if (typeof parentTemplateImages !== 'undefined') {
             templateObj.images = templateObj.images ?
                 Object.assign(parentTemplateImages, templateObj.images || {}) :
                 parentTemplateImages;
+        }
+
+        // If template.images contains a label match for the image defined in the job
+        // set the job image to the respective template image
+        if (typeof templateObj.images !== 'undefined'
+            && typeof templateObj.images[childJobConfig.image] !== 'undefined') {
+            childJobConfig.image = templateObj.images[childJobConfig.image];
         }
     }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -205,13 +205,6 @@ async function mergeTemplateIntoJob(templateObj, templateFactory) {
 
             newJob.templateId = template.id;
 
-            // If template.images contains a label match for the image defined in the job
-            // set the job image to the respective template image
-            if (typeof template.images !== 'undefined'
-                && typeof template.images[newJob.image] !== 'undefined') {
-                newJob.image = template.images[newJob.image];
-            }
-
             return {
                 childJobConfig: newJob,
                 parentTemplateImages: template.images,

--- a/test/data/valid_template_with_order_template.yaml
+++ b/test/data/valid_template_with_order_template.yaml
@@ -4,7 +4,6 @@ description: template description
 maintainer: name@domain.org
 images:
     test-image: node:18
-    stable-image: node:10
 config:
   template: template_namespace/parent@1
   image: stable-image

--- a/test/data/valid_template_with_order_warnings_template.yaml
+++ b/test/data/valid_template_with_order_warnings_template.yaml
@@ -4,7 +4,6 @@ description: template description
 maintainer: name@domain.org
 images:
     test-image: node:18
-    stable-image: node:10
 config:
   template: template_namespace/parent@1
   image: stable-image

--- a/test/data/valid_template_with_order_wrong_teardown_template.yaml
+++ b/test/data/valid_template_with_order_wrong_teardown_template.yaml
@@ -2,9 +2,6 @@ name: template_namespace/child
 version: 1.2.3
 description: template description
 maintainer: name@domain.org
-images:
-    test-image: node:18
-    stable-image: node:10
 config:
   template: template_namespace/parent@1
   image: stable-image

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe('index test', () => {
                                 SD_TEMPLATE_NAMESPACE: 'template_namespace',
                                 SD_TEMPLATE_VERSION: '1.2.3'
                             },
-                            image: 'node:8',
+                            image: 'node:10',
                             secrets: [
                                 'GIT_KEY',
                                 'SECRET_NAME'
@@ -183,7 +183,7 @@ describe('index test', () => {
                         description: 'template description',
                         images: {
                             'latest-image': 'node:12',
-                            'stable-image': 'node:10',
+                            'stable-image': 'node:8',
                             'test-image': 'node:18'
                         },
                         maintainer: 'name@domain.org',
@@ -246,8 +246,7 @@ describe('index test', () => {
                         description: 'template description',
                         images: {
                             'latest-image': 'node:12',
-                            'stable-image': 'node:10',
-                            'test-image': 'node:18'
+                            'stable-image': 'node:8'
                         },
                         maintainer: 'name@domain.org',
                         name: 'template_namespace/child',
@@ -303,7 +302,7 @@ describe('index test', () => {
                         description: 'template description',
                         images: {
                             'latest-image': 'node:12',
-                            'stable-image': 'node:10',
+                            'stable-image': 'node:8',
                             'test-image': 'node:18'
                         },
                         maintainer: 'name@domain.org',


### PR DESCRIPTION
## Context

For template composition, when the `images` object is merged, the current template's `images` definition should take priority over the parent template's `images` when using an `image` alias (e.g. `image: stable`).

## Objective

This PR sets the template's image based off the merged `images` object.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
