### PR TITLE
feat(2331): Support locked steps [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function parseTemplate(yamlString, templateFactory) {
     try {
         configToValidate = await loadTemplate(yamlString);
         const config = await validateTemplateStructure(configToValidate);
-        // Retrieve template and merge into job config
+        // Retrieve parent template and merge into job config
         const { flattenedConfig, warnMessages } = await flattenTemplate(
             config, templateFactory);
         const res = {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -105,11 +105,11 @@ function merge(newJob, oldJob, fromTemplate) {
 
             stepName = oldJob.order[i];
 
-            if (Hoek.reach(newSteps[stepName], 'locked')) {
-                step = { [stepName]: newSteps[stepName] };
-            } else if (oldSteps && oldSteps[stepName]) {
+            const stepLocked = Hoek.reach(newSteps[stepName], 'locked');
+
+            if (!stepLocked && Hoek.reach(oldSteps, stepName)) {
                 step = { [stepName]: oldSteps[stepName] };
-            } else if (newSteps && newSteps[stepName]) {
+            } else if (stepLocked || Hoek.reach(newSteps, stepName)) {
                 step = { [stepName]: newSteps[stepName] };
             } else {
                 warnings = warnings.concat(`${stepName} step definition not found; skipping`);
@@ -163,9 +163,7 @@ function merge(newJob, oldJob, fromTemplate) {
             }
 
             // If template step is locked or user doesn't define the same step, add it
-            if (Hoek.reach(newJob.steps[i][stepName], 'locked')) {
-                mergedSteps.push(newJob.steps[i]);
-            } else if (!oldSteps[stepName]) {
+            if (Hoek.reach(newJob.steps[i][stepName], 'locked') || !oldSteps[stepName]) {
                 mergedSteps.push(newJob.steps[i]);
             } else if (!stepName.startsWith('teardown-')) {
                 // If user defines the same step, only add if it's not teardown and not locked

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -6,16 +6,28 @@ const Hoek = require('@hapi/hoek');
  * Convert job steps from array to object for faster lookup
  * @method convertFromArrayToObject
  * @param  {Array} steps Job step array of objects
- * @return {Object}      Job object
+ * @return {Object}      Object with: job object, array of lockedStepNames
  */
 function convertFromArrayToObject(steps) {
-    return steps.reduce((obj, item) => {
+    const lockedStepNames = [];
+    const stepObj = steps.reduce((obj, item) => {
         const key = Object.keys(item)[0];
+        const substepKeys = typeof item[key] === 'object' ? Object.keys(item[key]) : undefined;
 
-        obj[key] = item[key];
+        // Compress step if only has command key
+        if (substepKeys && substepKeys.length === 1) {
+            obj[key] = item[key].command;
+        } else {
+            if (substepKeys && substepKeys.includes('locked')) {
+                lockedStepNames.push(key);
+            }
+            obj[key] = item[key];
+        }
 
         return obj;
     }, {});
+
+    return { stepObj, lockedStepNames };
 }
 /**
  * Merge oldJob into newJob
@@ -65,7 +77,7 @@ function merge(newJob, oldJob, fromTemplate) {
     newsourcePaths = Array.isArray(newsourcePaths) ? newsourcePaths : [newsourcePaths];
     oldsourcePaths = Array.isArray(oldsourcePaths) ? oldsourcePaths : [oldsourcePaths];
 
-    // remove duplicate
+    // Remove duplicate
     newJob.secrets = [...new Set([...newSecrets, ...oldSecrets])];
     newJob.sourcePaths = [...new Set([...newsourcePaths, ...oldsourcePaths])];
 
@@ -77,15 +89,25 @@ function merge(newJob, oldJob, fromTemplate) {
         const teardownSteps = [];
 
         // Convert steps from array to object for faster lookup
-        const oldSteps = convertFromArrayToObject(oldJob.steps);
-        const newSteps = convertFromArrayToObject(newJob.steps);
+        const { stepObj: oldSteps } = convertFromArrayToObject(oldJob.steps);
+        const { stepObj: newSteps, lockedStepNames } = convertFromArrayToObject(newJob.steps);
+
+        // Order must contain locked steps
+        const orderContainsLockedSteps = lockedStepNames.every(v => oldJob.order.includes(v));
+
+        if (!orderContainsLockedSteps) {
+            // eslint-disable-next-line max-len
+            throw new Error(`Order must contain template ${oldJob.template} locked steps: ${lockedStepNames}`);
+        }
 
         for (let i = 0; i < oldJob.order.length; i += 1) {
             let step;
 
             stepName = oldJob.order[i];
 
-            if (oldSteps && oldSteps[stepName]) {
+            if (Hoek.reach(newSteps[stepName], 'locked')) {
+                step = { [stepName]: newSteps[stepName] };
+            } else if (oldSteps && oldSteps[stepName]) {
                 step = { [stepName]: oldSteps[stepName] };
             } else if (newSteps && newSteps[stepName]) {
                 step = { [stepName]: newSteps[stepName] };
@@ -111,15 +133,21 @@ function merge(newJob, oldJob, fromTemplate) {
         const mergedSteps = [];
         const teardownSteps = [];
 
-        // convert steps from oldJob from array to object for faster lookup
+        // Convert steps from oldJob from array to object for faster lookup
         const oldSteps = oldJob.steps.reduce((obj, item) => {
             const key = Object.keys(item)[0];
+            const substepKeys = typeof item[key] === 'object' ? Object.keys(item[key]) : undefined;
 
             if (key.startsWith('teardown-')) {
                 teardownSteps.push(key);
             }
 
-            obj[key] = item[key];
+            // Compress step if only has command key
+            if (substepKeys && substepKeys.length === 1) {
+                obj[key] = item[key].command;
+            } else {
+                obj[key] = item[key];
+            }
 
             return obj;
         }, {});
@@ -129,21 +157,23 @@ function merge(newJob, oldJob, fromTemplate) {
             preStepName = `pre${stepName}`;
             postStepName = `post${stepName}`;
 
-            // add pre-step
+            // Add pre-step
             if (oldSteps[preStepName]) {
                 mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
             }
 
-            // if user doesn't define the same step, add it
-            if (!oldSteps[stepName]) {
+            // If template step is locked or user doesn't define the same step, add it
+            if (Hoek.reach(newJob.steps[i][stepName], 'locked')) {
+                mergedSteps.push(newJob.steps[i]);
+            } else if (!oldSteps[stepName]) {
                 mergedSteps.push(newJob.steps[i]);
             } else if (!stepName.startsWith('teardown-')) {
-                // if user defines the same step, only add if it's not teardown
-                // otherwise, skip (it will be overriden later, otherwise will get duplicate steps)
+                // If user defines the same step, only add if it's not teardown and not locked
+                // otherwise, skip (it will be overwritten later, otherwise will get duplicate steps)
                 mergedSteps.push({ [stepName]: oldSteps[stepName] });
             }
 
-            // add post-step
+            // Add post-step
             if (oldSteps[postStepName]) {
                 mergedSteps.push({ [postStepName]: oldSteps[postStepName] });
             }
@@ -173,7 +203,7 @@ async function mergeTemplateIntoJob(templateObj, templateFactory) {
     // Child template config
     const oldJob = templateObj.config;
 
-    // Try to get the template
+    // Try to get the parent template
     return templateFactory.getTemplate(oldJob.template)
         .then((template) => {
             if (!template) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@hapi/hoek": "^9.0.4",
     "joi": "^17.1.1",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "^21.1.5"
+    "screwdriver-data-schema": "^21.2.0"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@hapi/hoek": "^9.0.4",
     "joi": "^17.1.1",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "^21.0.0"
+    "screwdriver-data-schema": "^21.1.5"
   },
   "release": {
     "debug": false,

--- a/test/data/bad_order_missing_locked_step_template.yaml
+++ b/test/data/bad_order_missing_locked_step_template.yaml
@@ -1,0 +1,26 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  order:
+    - init
+    - test
+    - blah
+    - finish
+    - meow
+  steps:
+    - init:
+        command: echo Starting command
+        locked: true
+    - security: ./run_script.sh
+    - finish:
+        command: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/template_locked_step.json
+++ b/test/data/template_locked_step.json
@@ -1,0 +1,36 @@
+{
+    "id": 7754,
+    "namespace": "template_namespace",
+    "name": "parent",
+    "version": "1.2.3",
+    "description": "test template",
+    "maintainer": "bar@foo.com",
+    "labels": [],
+    "images": {
+        "stable-image": "node:8",
+        "latest-image": "node:12"
+    },
+    "config": {
+        "image": "node:4",
+        "steps": [
+            { "install": "npm install" },
+            { "test": "npm test" },
+            { "security": {
+                "command": "npm scan",
+                "locked": true
+                }
+            },
+            { "teardown-run": "cp -r artifacts/coverage $SD_ARTIFACTS_DIR" }
+        ],
+        "environment": {
+            "FOO": "from template",
+            "BAR": "foo"
+        },
+        "secrets": [
+            "GIT_KEY"
+        ],
+        "settings": {
+            "email": "foo@example.com"
+        }
+    }
+}

--- a/test/data/valid_extended_steps_template.json
+++ b/test/data/valid_extended_steps_template.json
@@ -1,0 +1,29 @@
+{
+    "errors": [],
+    "template": {
+        "config": {
+            "environment": {
+                "KEYNAME": "value"
+            },
+            "image": "image_name:image_tag",
+            "secrets": [
+                "SECRET_NAME"
+            ],
+            "steps": [
+                {
+                    "first_step": "first_command"
+                },
+                {
+                    "second_step": {
+                        "command": "./second_script.sh",
+                        "locked": true
+                    }
+                }
+            ]
+        },
+        "description": "template description",
+        "maintainer": "name@domain.org",
+        "name": "template_namespace/template_name",
+        "version": "1.2.3"
+    }
+}

--- a/test/data/valid_extended_steps_template.yaml
+++ b/test/data/valid_extended_steps_template.yaml
@@ -1,0 +1,15 @@
+name: template_namespace/template_name
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+config:
+  image: image_name:image_tag
+  steps:
+    - first_step: first_command
+    - second_step:
+        command: ./second_script.sh
+        locked: true
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/valid_order_and_locked_step_template.json
+++ b/test/data/valid_order_and_locked_step_template.json
@@ -1,0 +1,60 @@
+{
+    "errors": [],
+    "template": {
+        "config": {
+            "annotations": {},
+            "environment": {
+                "BAR": "foo",
+                "FOO": "from template",
+                "KEYNAME": "value",
+                "SD_TEMPLATE_FULLNAME": "template_namespace/parent",
+                "SD_TEMPLATE_NAME": "parent",
+                "SD_TEMPLATE_NAMESPACE": "template_namespace",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "image": "node:8",
+            "secrets": [
+                "GIT_KEY",
+                "SECRET_NAME"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "sourcePaths": [],
+            "steps": [
+                {
+                    "init": {
+                        "command": "echo Starting command",
+                        "locked": true
+                    }
+                },
+                {
+                    "security": {
+                        "command": "npm scan",
+                        "locked": true
+                    }
+                },
+                {
+                    "test": "npm test"
+                },
+                {
+                    "finish": "echo done!"
+                }
+            ],
+            "templateId": 7754
+        },
+        "description": "template description",
+        "images": {
+            "latest-image": "node:12",
+            "stable-image": "node:8",
+            "test-image": "node:18"
+        },
+        "maintainer": "name@domain.org",
+        "name": "template_namespace/child",
+        "version": "1.2.3"
+    },
+    "warnMessages": [
+        "blah step definition not found; skipping",
+        "meow step definition not found; skipping"
+    ]
+}

--- a/test/data/valid_order_and_locked_step_template.yaml
+++ b/test/data/valid_order_and_locked_step_template.yaml
@@ -1,0 +1,27 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  order:
+    - init
+    - security
+    - test
+    - blah
+    - finish
+    - meow
+  steps:
+    - init:
+        command: echo Starting command
+        locked: true
+    - security: ./run_script.sh
+    - finish:
+        command: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME

--- a/test/data/valid_parent_and_locked_step_template.json
+++ b/test/data/valid_parent_and_locked_step_template.json
@@ -1,0 +1,62 @@
+{
+    "errors": [],
+    "template": {
+        "config": {
+            "annotations": {},
+            "environment": {
+                "BAR": "foo",
+                "FOO": "from template",
+                "KEYNAME": "value",
+                "SD_TEMPLATE_FULLNAME": "template_namespace/parent",
+                "SD_TEMPLATE_NAME": "parent",
+                "SD_TEMPLATE_NAMESPACE": "template_namespace",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "image": "node:10",
+            "secrets": [
+                "GIT_KEY",
+                "SECRET_NAME"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "sourcePaths": [],
+            "steps": [
+                {
+                    "preinstall": "echo Starting command"
+                },
+                {
+                    "install": "first_command"
+                },
+                {
+                    "test": "npm test"
+                },
+                {
+                    "posttest": "./second_script.sh"
+                },
+                {
+                    "security": {
+                        "command": "npm scan",
+                        "locked": true
+                    }
+                },
+                {
+                    "teardown-run": "cp -r artifacts/coverage $SD_ARTIFACTS_DIR"
+                },
+                {
+                    "teardown-always": "echo done!"
+                }
+            ],
+            "templateId": 7754
+        },
+        "description": "template description",
+        "images": {
+            "latest-image": "node:12",
+            "stable-image": "node:10",
+            "test-image": "node:18"
+        },
+        "maintainer": "name@domain.org",
+        "name": "template_namespace/child",
+        "version": "1.2.3"
+    }
+}

--- a/test/data/valid_parent_and_locked_step_template.yaml
+++ b/test/data/valid_parent_and_locked_step_template.yaml
@@ -1,0 +1,21 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+images:
+    test-image: node:18
+    stable-image: node:10
+config:
+  template: template_namespace/parent@1
+  image: stable-image
+  steps:
+    - preinstall: echo Starting command
+    - install:
+        command: first_command
+    - security: echo Skip
+    - posttest: ./second_script.sh
+    - teardown-always: echo done!
+  environment:
+    KEYNAME: value
+  secrets:
+     - SECRET_NAME


### PR DESCRIPTION
## Context

It would be nice if template owners could specify which steps in their template cannot be modified or must be run.

## Objective

This PR: adds support for new `locked` field under step definition: when using `order`, checks that all `locked` steps are included. Also compresses step definition if only `command` field.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331
Blocked by https://github.com/screwdriver-cd/data-schema/pull/437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
