### PR TITLE
fix(2331): Warn when trying to override locked step

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -111,6 +111,10 @@ function merge(newJob, oldJob, fromTemplate) {
                 step = { [stepName]: oldSteps[stepName] };
             } else if (stepLocked || Hoek.reach(newSteps, stepName)) {
                 step = { [stepName]: newSteps[stepName] };
+                if (stepLocked && Hoek.reach(oldSteps, stepName)) {
+                    // eslint-disable-next-line max-len
+                    warnings = warnings.concat(`Cannot override locked step ${stepName}; using step definition from template ${oldJob.template}`);
+                }
             } else {
                 warnings = warnings.concat(`${stepName} step definition not found; skipping`);
             }
@@ -162,9 +166,15 @@ function merge(newJob, oldJob, fromTemplate) {
                 mergedSteps.push({ [preStepName]: oldSteps[preStepName] });
             }
 
+            const stepLocked = Hoek.reach(newJob.steps[i][stepName], 'locked');
+
             // If template step is locked or user doesn't define the same step, add it
-            if (Hoek.reach(newJob.steps[i][stepName], 'locked') || !oldSteps[stepName]) {
+            if (stepLocked || !oldSteps[stepName]) {
                 mergedSteps.push(newJob.steps[i]);
+                if (stepLocked && oldSteps[stepName]) {
+                    // eslint-disable-next-line max-len
+                    warnings = warnings.concat(`Cannot override locked step ${stepName}; using step definition from template ${oldJob.template}`);
+                }
             } else if (!stepName.startsWith('teardown-')) {
                 // If user defines the same step, only add if it's not teardown and not locked
                 // otherwise, skip (it will be overwritten later, otherwise will get duplicate steps)

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "mocha": "^8.2.1",
+    "mocha": "^8.3.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "nyc": "^15.0.0",
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "joi": "^17.1.1",
+    "joi": "^17.4.0",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "^21.2.0"
+    "screwdriver-data-schema": "^21.2.4"
   },
   "release": {
     "debug": false,

--- a/test/data/valid_order_and_locked_step_template.json
+++ b/test/data/valid_order_and_locked_step_template.json
@@ -54,6 +54,7 @@
         "version": "1.2.3"
     },
     "warnMessages": [
+        "Cannot override locked step security; using step definition from template template_namespace/parent@1",
         "blah step definition not found; skipping",
         "meow step definition not found; skipping"
     ]

--- a/test/data/valid_parent_and_locked_step_template.json
+++ b/test/data/valid_parent_and_locked_step_template.json
@@ -58,5 +58,8 @@
         "maintainer": "name@domain.org",
         "name": "template_namespace/child",
         "version": "1.2.3"
-    }
+    },
+    "warnMessages": [
+        "Cannot override locked step security; using step definition from template template_namespace/parent@1"
+    ]
 }


### PR DESCRIPTION
## Context

It would be nice if users could see a warning when trying to override locked steps.

## Objective

This PR adds a warning for trying to override locked steps.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
