### PR TITLE
fix(2457): Allow empty steps when using template and order

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const SCHEMA_CONFIG = require('screwdriver-data-schema').config.template.template;
 const Yaml = require('js-yaml');
-const helper = require('./lib/helper.js');
+const helper = require('./lib/helper');
 
 /**
  * Loads the configuration from a stringified screwdriver-template.yaml

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -10,6 +10,11 @@ const Hoek = require('@hapi/hoek');
  */
 function convertFromArrayToObject(steps) {
     const lockedStepNames = [];
+
+    if (!steps || steps.length === 0) {
+        return { stepObj: {}, lockedStepNames };
+    }
+
     const stepObj = steps.reduce((obj, item) => {
         const key = Object.keys(item)[0];
         const substepKeys = typeof item[key] === 'object' ? Object.keys(item[key]) : undefined;

--- a/package.json
+++ b/package.json
@@ -31,20 +31,20 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.3.0",
+    "chai": "^4.3.4",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
-    "mocha": "^8.3.0",
+    "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "nyc": "^15.0.0",
     "sinon": "^9.2.4"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.4",
+    "@hapi/hoek": "^9.2.0",
     "joi": "^17.4.0",
     "js-yaml": "^3.12.1",
-    "screwdriver-data-schema": "^21.2.4"
+    "screwdriver-data-schema": "^21.3.0"
   },
   "release": {
     "debug": false,

--- a/test/data/valid_order_no_steps_template.json
+++ b/test/data/valid_order_no_steps_template.json
@@ -1,0 +1,43 @@
+{
+    "errors": [],
+    "template": {
+        "config": {
+            "annotations": {},
+            "environment": {
+                "BAR": "foo",
+                "FOO": "from template",
+                "KEYNAME": "value",
+                "SD_TEMPLATE_FULLNAME": "template_namespace/parent",
+                "SD_TEMPLATE_NAME": "parent",
+                "SD_TEMPLATE_NAMESPACE": "template_namespace",
+                "SD_TEMPLATE_VERSION": "1.2.3"
+            },
+            "image": "node:4",
+            "secrets": [
+                "GIT_KEY",
+                "SECRET_NAME"
+            ],
+            "settings": {
+                "email": "foo@example.com"
+            },
+            "sourcePaths": [],
+            "steps": [
+                {
+                    "install": "npm install"
+                },
+                {
+                    "test": "npm test"
+                }
+            ],
+            "templateId": 7754
+        },
+        "description": "template description",
+        "images": {
+            "latest-image": "node:12",
+            "stable-image": "node:8"
+        },
+        "maintainer": "name@domain.org",
+        "name": "template_namespace/child",
+        "version": "1.2.3"
+    }
+}

--- a/test/data/valid_order_no_steps_template.yaml
+++ b/test/data/valid_order_no_steps_template.yaml
@@ -1,0 +1,13 @@
+name: template_namespace/child
+version: 1.2.3
+description: template description
+maintainer: name@domain.org
+config:
+  template: template_namespace/parent@1
+  order:
+    - install
+    - test
+  environment:
+    KEYNAME: value
+  secrets:
+    - SECRET_NAME

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@ const VALID_EXTENDED_STEPS_TEMPLATE_PATH = 'valid_extended_steps_template.yaml';
 const VALID_PARENT_TEMPLATE_PATH = 'valid_parent_template.yaml';
 const VALID_PARENT_LOCKED_TEMPLATE_PATH = 'valid_parent_and_locked_step_template.yaml';
 const VALID_ORDER_TEMPLATE_PATH = 'valid_order_template.yaml';
+const VALID_ORDER_NO_STEPS_TEMPLATE_PATH = 'valid_order_no_steps_template.yaml';
 const INVALID_ORDER_TEMPLATE_PATH = 'invalid_order_template.yaml';
 const VALID_ORDER_WRONG_TEARDOWN_TEMPLATE_PATH = 'valid_order_and_wrong_teardown_template.yaml';
 const VALID_ORDER_WITH_WARNINGS_PATH = 'valid_order_and_warnings_template.yaml';
@@ -87,6 +88,15 @@ describe('index test', () => {
             .then((config) => {
                 assert.isObject(config);
                 assert.deepEqual(config, JSON.parse(loadData('valid_order_template.json')));
+            })
+    );
+
+    it('parses a valid yaml using a parent template with order and no steps defined', () =>
+        validator(loadData(VALID_ORDER_NO_STEPS_TEMPLATE_PATH), templateFactoryMock)
+            .then((config) => {
+                assert.isObject(config);
+                assert.deepEqual(config, JSON.parse(loadData(
+                    'valid_order_no_steps_template.json')));
             })
     );
 


### PR DESCRIPTION
## Context

Sometimes template owners might define a template using a parent template and order (without steps defined). This should be allowed.

## Objective

This PR fixes error when steps does not exist.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2457

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
