### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@hapi/hoek": "^10.0.1",
     "joi": "^17.7.0",
     "js-yaml": "^4.1.0",
-    "screwdriver-data-schema": "^23.5.1",
-    "screwdriver-config-parser": "^10.4.3"
+    "screwdriver-config-parser": "^11.0.0",
+    "screwdriver-data-schema": "^24.0.0"
   },
   "release": {
     "debug": false

--- a/test/data/valid_full_pipeline_template_parsed.json
+++ b/test/data/valid_full_pipeline_template_parsed.json
@@ -160,6 +160,32 @@
               "description": "User running build"
             }
           }
+        },
+        "workflowGraph": {
+            "edges": [
+                {
+                    "dest": "main",
+                    "src": "~commit"
+                },
+                {
+                    "dest": "test",
+                    "src": "~commit"
+                }
+            ],
+            "nodes": [
+                {
+                    "name": "~pr"
+                },
+                {
+                    "name": "~commit"
+                },
+                {
+                    "name": "main"
+                },
+                {
+                    "name": "test"
+                }
+            ]
         }
       }
 }

--- a/test/data/valid_full_pipeline_template_validated.json
+++ b/test/data/valid_full_pipeline_template_validated.json
@@ -172,33 +172,33 @@
               "value": "sd-bot",
               "description": "User running build"
             }
-          },
-          "workflowGraph": {
+          }
+        },
+        "workflowGraph": {
             "edges": [
-              {
-                "dest": "main",
-                "src": "~commit"
-              },
-              {
-                "dest": "test",
-                "src": "~commit"
-              }
+                {
+                    "dest": "main",
+                    "src": "~commit"
+                },
+                {
+                    "dest": "test",
+                    "src": "~commit"
+                }
             ],
             "nodes": [
-              {
-                "name": "~pr"
-              },
-              {
-                "name": "~commit"
-              },
-              {
-                "name": "main"
-              },
-              {
-                "name": "test"
-              }
+                {
+                    "name": "~pr"
+                },
+                {
+                    "name": "~commit"
+                },
+                {
+                    "name": "main"
+                },
+                {
+                    "name": "test"
+                }
             ]
-          }
         }
       }
 }


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 (and related PRs) to store `workflowGraph` of pipeline template as part of the `config` 

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
